### PR TITLE
linting

### DIFF
--- a/examples/create_peers_ecix.py
+++ b/examples/create_peers_ecix.py
@@ -12,6 +12,6 @@ for member in ixp_data['member_list']:
     for vlan in connection['vlan_list']:
       if 'ipv4' in vlan:
         print '-----'
-        print 'neighbor '+vlan['ipv4']['address']+' remote-as '+member['asnum']
+        print 'neighbor '+vlan['ipv4']['address']+' remote-as '+ str(member['asnum'])
         print 'neighbor '+vlan['ipv4']['address']+' description PEER::'+member['name']
 


### PR DESCRIPTION
print statement in create_peers_ecix.py was modified to accommodate that type(member['asnum']) is integer.