### PR TITLE
Allow multiple MAC addressing and separate by address family

### DIFF
--- a/ixp-member-list.schema.json
+++ b/ixp-member-list.schema.json
@@ -311,7 +311,7 @@
                             }
                           }
                         }
-                      
+
 
                     },
                     "vlan_list": {
@@ -325,10 +325,6 @@
                             "vlan_id": {
                               "description": "The VLAN ID this connection is placed in, persistent value free to set by the IXP",
                               "type": "integer"
-                            },
-                            "mac_address": {
-                              "description": "MAC address of the member interface",
-                              "type": "string"
                             },
                             "ipv4": {
                               "description": "The network's IPv4 address details in this VLAN",
@@ -351,6 +347,13 @@
                                 "routeserver": {
                                   "description": "Does this IPv4 address connect to the IXP routeserver",
                                   "type": "boolean"
+                                },
+                                "mac_addresses": {
+                                  "description": "MAC address of the member interface (format: lowercase string xx:xx:xx:xx:xx:xx)",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 }
                               }
                             },
@@ -375,21 +378,28 @@
                                 "routeserver": {
                                   "description": "Does this IPv6 address connect to the IXP routeserver",
                                   "type": "boolean"
+                                },
+                                "mac_addresses": {
+                                  "description": "MAC address of the member interface (format: lowercase string xx:xx:xx:xx:xx:xx)",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 }
                               }
                             }
                           }
                         }
-                      
+
 
                     }
                   }
                 }
-              
+
             }
           }
         }
-      
+
     }
   }
 }

--- a/ixp-member-list.txt
+++ b/ixp-member-list.txt
@@ -29,14 +29,18 @@
 #       + spelin fixxups and apostrophe's
 # v 0.5 * included feedback from Arnold Nipper (DE-CIX):
 #       + pdb_facility_id added to switch
+# v 0.6 * included feedback from Arnold Nipper (DE-CIX):
+#       + allow multiple MACs per address family and list macs
+#         by address family as some IXPs allow different L3 interfaces
+#         for v4/v6
 
 
 #######################################################################
 # basic example
 
 {
-    "version": "0.5",
-    "timestamp": "2015-01-28T00:00:00Z",
+    "version": "0.6",
+    "timestamp": "2016-01-22T00:00:00Z",
     "ixp_list": [
        {
           "ixp_id": 42,
@@ -85,8 +89,8 @@
 # more complex example
 
 {
-    "version": "0.5",
-    "timestamp": "2015-01-28T00:00:00Z",
+    "version": "0.6",
+    "timestamp": "2016-01-22T00:00:00Z",
     "ixp_list": [
       {
         "shortname": "AMS-IX",
@@ -101,7 +105,7 @@
         "support_contact_hours": "8/5",
         "emergency_email": "noc@ams-ix.net",
         "emergency_phone": "+31 20 514 1717",
-        "emergency_contact_hours": "24/7", 
+        "emergency_contact_hours": "24/7",
         "billing_email": "info@ams-ix.net",
         "billing_phone": "+31 20 305 89 99",
         "billing_contact_hours": "8/5",
@@ -186,18 +190,23 @@
                     "vlan_list": [
                         {
                             "vlan_id": 0,
-                            "mac_address" : "00:0a:95:9d:68:16",
                             "ipv4": {
                                 "address": "195.69.146.250",
                                 "routeserver": true,
                                 "max_prefix": 42,
-                                "as_macro": "AS-NFLX-V4"
+                                "as_macro": "AS-NFLX-V4",
+                                "mac_address" : [
+                                    "00:0a:95:9d:68:16"
+                                ]
                             },
                             "ipv6": {
                                 "address": "2001:7f8:1::a500:2906:2",
                                 "routeserver": true,
                                 "max_prefix": 42,
-                                "as_macro": "AS-NFLX-V6"
+                                "as_macro": "AS-NFLX-V6",
+                                "mac_address" : [
+                                    "00:0a:95:9d:68:16"
+                                ]
                             }
                         }
                     ]
@@ -216,18 +225,23 @@
                     "vlan_list": [
                         {
                             "vlan_id": 0,
-                            "mac_address" : "00:0a:95:9d:68:16",
                             "ipv4": {
                                 "address": "195.69.147.250",
                                 "routeserver": true,
                                 "max_prefix": 42,
-                                "as_macro": "AS-NFLX-V4"
+                                "as_macro": "AS-NFLX-V4",
+                                "mac_address" : [
+                                    "00:0a:95:9d:68:16"
+                                ]
                             },
                             "ipv6": {
                                 "address": "2001:7f8:1::a500:2906:1",
                                 "routeserver": true,
                                 "max_prefix": 42,
-                                "as_macro": "AS-NFLX-V6"
+                                "as_macro": "AS-NFLX-V6",
+                                "mac_address" : [
+                                    "00:0a:95:9d:68:16"
+                                ]
                             }
                         }
                     ]
@@ -236,4 +250,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
Rationale:

Some IXPs allow / require different L3 interfaces per address family.

From a number of discussions, it seems allowing multiple MAC addressing per
interface is preferred for instances where IXPs allow this but also where
an IXP customer is migrating an interface.

Tested and validated examples against schema.