### PR TITLE
Add LINX to list of implementations of Euro-IX json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ More detailed documentation is available on the [github wiki page](https://githu
 15. [SFMIX](http://sfmix.org/participants.json)
 16. [RIX](http://rix.is/participants.json)
 17. [Telx](https://tie.telx.com/stats/members.json)
+18. [LINX](https://www.linx.net/members.json.php)
 
 ## Contact
 Please send feedback to: 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ More detailed documentation is available on the [github wiki page](https://githu
 15. [SFMIX](http://sfmix.org/participants.json)
 16. [RIX](http://rix.is/participants.json)
 17. [Telx](https://tie.telx.com/stats/members.json)
-18. [LINX](https://www.linx.net/members.json.php)
+18. [LINX](https://www.linx.net/members.json)
 
 ## Contact
 Please send feedback to: 


### PR DESCRIPTION
Adding LINX to list of implementations of the Euro-IX json schema. This requires a http basic auth login (restricted to LINX members only to protect LINX member email address data) so if you'd like to test the data against the schema please let me know and I'll provide sample output.
