### PR TITLE
Add basicauth support validator

### DIFF
--- a/examples/validate.py
+++ b/examples/validate.py
@@ -1,18 +1,62 @@
 #!/usr/bin/env python
 
-import json
-import jsonschema
 import sys
-import urllib
+import argparse
+import requests
+import jsonschema
 
-if len(sys.argv) != 2:
-    raise Exception('usage: validate.py <url>')
 
-url = sys.argv[1]
-schema_url = "https://raw.githubusercontent.com/euro-ix/json-schemas/master/ixp-member-list.schema.json"
+def parse_args(args):
+    schema_url = ('https://raw.githubusercontent.com'
+                  '/euro-ix/json-schemas/master/'
+                  'ixp-member-list.schema.json')
 
-schema = json.loads(urllib.urlopen(schema_url).read())
-ixp_data = json.loads(urllib.urlopen(url).read())
+    parser = argparse.ArgumentParser(
+        description='Validate json output against schema.'
+    )
+    parser.add_argument(
+        '-u',
+        '--username',
+        default=None,
+        help='HTTP Basic Auth User'
+    )
+    parser.add_argument(
+        '-p',
+        '--password',
+        default=None,
+        help='HTTP Basic Auth Password'
+    )
+    parser.add_argument(
+        '-s',
+        '--schema',
+        default=schema_url,
+        help='URL of json schema to validate against'
+    )
+    parser.add_argument('url', help='URL of json to validate')
+    return parser.parse_args(args)
 
-jsonschema.validate(ixp_data, schema)
 
+def main(argv=sys.argv[1:]):
+    args = parse_args(argv)
+
+    schema_url = args.schema
+    response = requests.get(schema_url)
+    schema = response.json()
+
+    if args.username and args.password:
+        response = requests.get(
+            args.url,
+            auth=(
+                args.username,
+                args.password
+            )
+        )
+    else:
+        response = requests.get(args.url)
+
+    ixp_data = response.json()
+    jsonschema.validate(ixp_data, schema)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
While testing the LINX implementation of the euro-ix json schema I was struggling to run the validator against the LINX implementation because it was behind http basic auth. I've therefore provided a PR with a suggested change to validate.py to allow a few more optional commandline arguments to support basic auth. (LINX has since made it's json export public but there you go...).

I changed from using the urllib module to the requests module, this has the advantage of providing an easier way to handle http basic auth requests, as well as providing python3 compatibility (since urllib changes between 2 and 3). The disadvantage is that requests is a non-core module so would need to be installed on the host running this. 

Any questions / comments / feedback please drop me a line. 