### PR TITLE
Add as_macro_source field

### DIFF
--- a/ixp-member-list.schema.json
+++ b/ixp-member-list.schema.json
@@ -340,6 +340,10 @@
                                   "description": "The IPv4 AS-MACRO, if applicable",
                                   "type": "string"
                                 },
+                                "as_macro_source": {
+                                  "description": "The IPv4 AS-MACRO IRR, if applicable",
+                                  "type": "string"
+                                },
                                 "max_prefix": {
                                   "description": "The max number of prefixes on this connection for IPv4",
                                   "type": "integer"
@@ -369,6 +373,10 @@
                                 },
                                 "as_macro": {
                                   "description": "The IPv6 AS-MACRO, if applicable",
+                                  "type": "string"
+                                },
+                                "as_macro_source": {
+                                  "description": "The IPv6 AS-MACRO IRR, if applicable",
                                   "type": "string"
                                 },
                                 "max_prefix": {

--- a/ixp-member-list.txt
+++ b/ixp-member-list.txt
@@ -195,6 +195,7 @@
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V4",
+                                "as_macro_source": "RADB",
                                 "mac_addresses" : [
                                     "00:0a:95:9d:68:16"
                                 ]
@@ -204,6 +205,7 @@
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V6",
+                                "as_macro_source": "RADB",
                                 "mac_addresses" : [
                                     "00:0a:95:9d:68:16"
                                 ]
@@ -230,6 +232,7 @@
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V4",
+                                "as_macro_source": "RADB",
                                 "mac_addresses" : [
                                     "00:0a:95:9d:68:16"
                                 ]
@@ -239,6 +242,7 @@
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V6",
+                                "as_macro_source": "RADB",
                                 "mac_addresses" : [
                                     "00:0a:95:9d:68:16"
                                 ]


### PR DESCRIPTION
Allow to specify the source IRR for an as_macro. It will allow scripts to ask the requested registry for the macro / autnum. 