### PR TITLE
V1.0

### DIFF
--- a/ixp-member-list.schema.json
+++ b/ixp-member-list.schema.json
@@ -151,6 +151,10 @@
                     "model": {
                       "description": "Free text field to indicate the model of the switch for informational purposes. Should not be present without manufacturer.",
                       "type": "string"
+                    },
+                    "software": {
+                      "description": "Free text field to indicate the software of the switch for informational purposes.",
+                      "type": "string"
                     }
                   }
                 }
@@ -383,11 +387,34 @@
                                     "type": "string"
                                   }
                                 },
-                                "service_type": {
-                                  "description": "ENUM field to indicate the service type(s) available from this connection. Defined types: 'ixrouteserver' (IX operated route server), 'ixroutecollector' (IX operated route collector)",
+                                "services": {
+                                  "description": "Array of IX operated service(s) available from this connection.",
                                   "type": "array",
                                   "items": {
-                                    "type": "string"
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "description": "The IX operated service available from this connection.",
+                                        "type": "string",
+                                        "enum": ["ixroutecollector", "ixrouteserver"]
+                                      },
+                                      "os": {
+                                        "description": "Free text field to indicate the operating system of the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "os_version": {
+                                        "description": "Free text field to indicate the operating system version of the route server for informational purposes. Should not be present without os.",
+                                        "type": "string",
+                                      },
+                                      "daemon": {
+                                          "description": "Free text field to indicate the BGP software daemon that provides the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "daemon_version": {
+                                          "description": "Free text field to indicate the BGP software daemon version that provides the route server for informational purposes. Should not be present without daemon.",
+                                        "type": "string",
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -421,11 +448,34 @@
                                     "type": "string"
                                   }
                                 },
-                                "service_type": {
-                                  "description": "ENUM field to indicate the service type(s) available from this connection. Defined types: 'ixrouteserver' (IX operated route server), 'ixroutecollector' (IX operated route collector)",
+                                "services": {
+                                  "description": "Array of IX operated service(s) available from this connection.",
                                   "type": "array",
                                   "items": {
-                                    "type": "string"
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "description": "The IX operated service available from this connection.",
+                                        "type": "string",
+                                        "enum": ["ixroutecollector", "ixrouteserver"]
+                                      },
+                                      "os": {
+                                        "description": "Free text field to indicate the operating system of the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "os_version": {
+                                        "description": "Free text field to indicate the operating system version of the route server for informational purposes. Should not be present without os.",
+                                        "type": "string",
+                                      },
+                                      "daemon": {
+                                          "description": "Free text field to indicate the BGP software daemon that provides the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "daemon_version": {
+                                          "description": "Free text field to indicate the BGP software daemon version that provides the route server for informational purposes. Should not be present without daemon.",
+                                        "type": "string",
+                                      }
+                                    }
                                   }
                                 }
                               }

--- a/ixp-member-list.txt
+++ b/ixp-member-list.txt
@@ -2,10 +2,13 @@
 #######################################################################
 # IX Member List Schema
 #
-# Elisa Jasinska <elisa@bigwaveit.org>
-# Nick Hilliard <nick@inex.ie>
+# Elisa Jasinska
+# Nick Hilliard
+# Bijal Sanghani
+# Barry O'Donovan
+# Arnold Nipper
 #
-# version 0.6 - 2016-04-26
+# version 1.0 - 2019-07-18
 #
 #
 # revision history:
@@ -41,6 +44,11 @@
 #       + add: looking_glass_urls (array of strings, not required) to vlan ipv4/6
 #       + add: service_type (array of strings, not required) to member connection
 #       - remove: types probono and routeserver from member_list.member_type
+# v 1.0 * added new fields following euro-ix requirements
+#       + add: software to switches: (string, not required)
+#       + refactor service_type to an array of objects called 'services'
+#         and add: os: (string, not required), os_version: (string, not required),
+#       daemon: (string, not required), and daemon_version: (string, not required)
 
 
 
@@ -48,8 +56,8 @@
 # basic example
 
 {
-    "version": "0.7",
-    "timestamp": "2017-01-30T00:00:00Z",
+    "version": "1.0",
+    "timestamp": "2019-07-18T00:00:00Z",
     "ixp_list": [
        {
           "ixp_id": 42,
@@ -99,8 +107,8 @@
 # more complex example
 
 {
-    "version": "0.7",
-    "timestamp": "2017-01-30T00:00:00Z",
+    "version": "1.0",
+    "timestamp": "2019-07-18T00:00:00Z",
     "ixp_list": [
       {
         "shortname": "AMS-IX",
@@ -136,7 +144,8 @@
                 "city": "Amsterdam",
                 "country": "NL",
                 "manufacturer": "Acme Switch Co.",
-                "model": "Big Switch"
+                "model": "Big Switch",
+                "software": "SwitchOS"
             },
             {
                 "id": 1,
@@ -173,13 +182,13 @@
     ],
     "member_list": [
         {
-            "asnum": 2906,
+            "asnum": 65505,
             "member_type": "peering",
             "name": "Netflix",
             "url": "http://netflix.com/",
             "contact_email": [
-                "peering@netflix.com",
-                "mrpeering@netflix.com"
+                "peering@example.com",
+                "mrpeering@example.com"
             ],
             "contact_phone": [
                 "+1 1234 5678"
@@ -204,21 +213,21 @@
                         {
                             "vlan_id": 0,
                             "ipv4": {
-                                "address": "195.69.146.250",
+                                "address": "192.0.2.250",
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V4",
                                 "mac_addresses" : [
-                                    "00:0a:95:9d:68:16"
+                                    "00:11:22:33:44:16"
                                 ]
                             },
                             "ipv6": {
-                                "address": "2001:7f8:1::a500:2906:2",
+                                "address": "2001:db8::250",
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V6",
                                 "mac_addresses" : [
-                                    "00:0a:95:9d:68:16"
+                                    "00:11:22:33:44:16"
                                 ]
                             }
                         }
@@ -239,21 +248,76 @@
                         {
                             "vlan_id": 0,
                             "ipv4": {
-                                "address": "195.69.147.250",
+                                "address": "192.0.2.100",
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V4",
                                 "mac_addresses" : [
-                                    "00:0a:95:9d:68:16"
+                                    "00:11:22:33:44:17"
                                 ]
                             },
                             "ipv6": {
-                                "address": "2001:7f8:1::a500:2906:1",
+                                "address": "2001:db8::100",
                                 "routeserver": true,
                                 "max_prefix": 42,
                                 "as_macro": "AS-NFLX-V6",
                                 "mac_addresses" : [
-                                    "00:0a:95:9d:68:16"
+                                    "00:11:22:33:44:17"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "asnum": 65500,
+            "member_type": "ixp",
+            "name": "Example IXP",
+            "url": "http://ixp.example.com/",
+            "peering_policy": "mandatory",
+            "member_since": "2000-02-04T00:00:00Z",
+            "connection_list": [
+                {
+                    "ixp_id": 42,
+                    "state": "active",
+                    "if_list": [
+                        {
+                            "switch_id": 0,
+                            "if_speed": 10000,
+                        }
+                    ],
+                    "vlan_list": [
+                        {
+                            "vlan_id": 2,
+                            "ipv4": {
+                                "address": "192.0.2.254",
+                                "routeserver": false,
+                                "max_prefix": 100000,
+                                "as_macro": "AS-EXAMPLE-IX-RS",
+                                "services": [
+                                    {
+                                        "type": "ixrouteserver",
+                                        "os": "Ubuntu Linux",
+                                        "os_version": "18.04",
+                                        "daemon": "bird",
+                                        "daemon_version": "1.6.2",
+                                    }
+                                ]
+                            },
+                            "ipv6": {
+                                "address": "2001:db8::254",
+                                "routeserver": false,
+                                "max_prefix": 10000,
+                                "as_macro": "AS-EXAMPLE-IX-RS-V6",
+                                "services": [
+                                    {
+                                        "type": "ixrouteserver",
+                                        "os": "Ubuntu Linux",
+                                        "os_version": "18.04",
+                                        "daemon": "bird",
+                                        "daemon_version": "1.6.2",
+                                    }
                                 ]
                             }
                         }

--- a/versions/ixp-member-list-1.0.schema.json
+++ b/versions/ixp-member-list-1.0.schema.json
@@ -1,0 +1,497 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "IXP Member List Schema",
+  "description": "A JSON schema representing an IXP Member List",
+  "type": "object",
+  "required": ["version", "timestamp", "ixp_list", "member_list"],
+  "properties": {
+
+    "version": {
+      "title": "IXP Member List Schema Version",
+      "description": "Version number of the schema; this is not the version of the file within an IXP; but the schema version",
+      "type": "string"
+    },
+
+    "timestamp": {
+      "title": "IXP Member List Schema export timestamp",
+      "description": "Timestamp of when the data was exported",
+      "type": "string",
+      "format": "date-time"
+    },
+
+    "ixp_list": {
+      "title": "IXP Info List",
+      "description": "A list of schemas representing IXP information",
+      "type": "array",
+      "items":
+        {
+          "description": "A single IXP entry",
+          "type": "object",
+          "required": ["ixf_id","ixp_id","shortname"],
+          "properties": {
+
+            "ixp_id": {
+              "description": "IXP numeric identifier, persistent value free to set by the IXP",
+              "type": "integer"
+            },
+            "shortname": {
+              "description": "Short name of the IXP",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the IXP",
+              "type": "string"
+            },
+            "url": {
+              "description": "Website of the IXP",
+              "type": "string",
+              "format": "uri"
+            },
+            "stats_api": {
+              "description": "URL to statistics API",
+              "type": "string",
+              "format": "uri"
+            },
+            "country": {
+              "description": "ISO country code where the IXP is located",
+              "type": "string"
+            },
+            "ixf_id": {
+              "description": "IXP ID from the IX-F database",
+              "type": "integer"
+            },
+            "peeringdb_id": {
+              "description": "PeeringDB ID of the IX - the y in: https://www.peeringdb.com/ix/y",
+              "type": "integer"
+            },
+            "support_email": {
+              "description": "Support email address",
+              "type": "string",
+              "format" : "email"
+            },
+            "support_phone": {
+              "description": "Support phone number",
+              "type": "string"
+            },
+            "support_contact_hours": {
+              "description": "Support contact hours, eg. 24/7, 8/5, etc",
+              "type": "string"
+            },
+            "emergency_email": {
+              "description": "Emergency support email address",
+              "type": "string",
+              "format" : "email"
+            },
+            "emergency_phone": {
+              "description": "Emergency support phone number",
+              "type": "string"
+            },
+            "emergency_contact_hours": {
+              "description": "Emergency support contact hours, eg. 24/7, 8/5, etc",
+              "type": "string"
+            },
+            "billing_email": {
+              "description": "Billing email address",
+              "type": "string",
+              "format" : "email"
+            },
+            "billing_phone": {
+              "description": "Billing phone number",
+              "type": "string"
+            },
+            "billing_contact_hours": {
+              "description": "Billing contact hours, eg. 24/7, 8/5, etc",
+              "type": "string"
+            },
+            "peering_policy_list": {
+              "description": "Peering policy choices available in the member list",
+              "type": "array",
+              "items":
+                {
+                  "type": "string"
+                }
+            },
+
+            "switch": {
+              "description": "Switches available at the IXP",
+              "type": "array",
+              "items":
+                {
+                  "type": "object",
+                  "properties": {
+
+                    "id": {
+                      "description": "Unique ID of the switch",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "Switch name",
+                      "type": "string"
+                    },
+                    "colo": {
+                      "description": "Colo the switch is located in",
+                      "type": "string"
+                    },
+                    "pdb_facility_id": {
+                      "description": "Peering DB ID of the data centre",
+                      "type": "integer"
+                    },
+                    "city": {
+                      "description": "City the switch is located in",
+                      "type": "string"
+                    },
+                    "country": {
+                      "description": "Country the switch is located in",
+                      "type": "string"
+                    },
+                    "manufacturer": {
+                      "description": "Free text field to indicate the manufacturer of the switch for informational purposes.",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Free text field to indicate the model of the switch for informational purposes. Should not be present without manufacturer.",
+                      "type": "string"
+                    },
+                    "software": {
+                      "description": "Free text field to indicate the software of the switch for informational purposes.",
+                      "type": "string"
+                    }
+                  }
+                }
+            },
+
+            "vlan": {
+              "description": "VLANs available at the IXP",
+              "type": "array",
+              "items":
+                {
+                  "description": "A single VLAN entry",
+                  "type": "object",
+                  "properties": {
+
+                    "id": {
+                      "description": "Unique ID of the VLAN",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "description": "VLAN name",
+                      "type": "string"
+                    },
+                    "ipv4": {
+                      "description": "IPv4 details in this VLAN",
+                      "type": "object",
+                      "properties": {
+
+                        "prefix": {
+                          "description": "Prefix of the IPv4 address",
+                          "type": "string",
+                          "format": "ipv4"
+                        },
+                        "mask_length": {
+                          "description": "Mask length of the IPv4 address",
+                          "type": "integer"
+                        },
+                        "looking_glass_urls": {
+                          "description": "URLs of looking glass(es) available for this VLAN and protocol.",
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    },
+                    "ipv6": {
+                      "description": "IPv6 details in this VLAN",
+                      "type": "object",
+                      "properties": {
+
+                        "prefix": {
+                          "description": "Prefix of the IPv6 address",
+                          "type": "string",
+                          "format": "ipv6"
+                        },
+                        "mask_length": {
+                          "description": "Mask length of the IPv6 address",
+                          "type": "integer"
+                        },
+                        "looking_glass_urls": {
+                          "description": "URLs of looking glass(es) available for this VLAN and protocol.",
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            }
+          }
+        }
+    },
+
+    "member_list": {
+      "title": "IXP Member List",
+      "description": "A list of schemas representing IXP members",
+      "type": "array",
+      "items":
+        {
+          "description": "A single member entry",
+          "type": "object",
+          "required": ["asnum","connection_list"],
+          "properties": {
+
+            "asnum": {
+              "description": "AS number of the network",
+              "type": "integer"
+            },
+            "member_type": {
+              "description": "Participant type: peering, ixp or other",
+              "type": "string",
+              "enum": ["peering","ixp","other"]
+            },
+            "name": {
+              "description": "Name of the network",
+              "type": "string"
+            },
+            "url": {
+              "description": "URL to website of the network",
+              "type": "string",
+              "format": "uri"
+            },
+            "peering_policy": {
+              "description": "Peering policy of the network",
+              "type": "string"
+            },
+            "peering_policy_url": {
+              "description": "URL to the network's peering policy",
+              "type": "string",
+              "format": "uri"
+            },
+            "member_since": {
+              "description": "Date when the network joined the IXP",
+              "type": "string",
+              "format": "date-time"
+            },
+            "contact_email": {
+              "description": "List of contact email addresses of the network",
+              "type": "array",
+              "items":
+                {
+                  "type": "string",
+                  "format" : "email"
+                }
+            },
+            "contact_phone": {
+              "description": "List of contact phone numbers of the network",
+              "type": "array",
+              "items":
+                {
+                  "type": "string"
+                }
+            },
+            "contact_hours": {
+              "description": "Network contact hours, eg. 24/7, 8/5, etc",
+              "type": "string"
+            },
+
+            "connection_list": {
+              "description": "List of connections of the network at the IXP",
+              "type": "array",
+              "items":
+                {
+                  "description": "A single connection entry",
+                  "type": "object",
+                  "required": ["ixp_id"],
+                  "properties": {
+
+                    "ixp_id": {
+                      "description": "IXP numeric identifier, persistent value free to set by the IXP, referencing the same ID as used in the ixp_list element",
+                      "type": "integer"
+                    },
+                    "state": {
+                      "description": "State of the connection",
+                      "type": "string"
+                    },
+                    "connected_since": {
+                      "description": "Date when the connection was activated",
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "if_list": {
+                      "description": "List of interfaces making up the connection",
+                      "type": "array",
+                      "items":
+                        {
+                          "description": "A single interface entry",
+                          "type": "object",
+                          "properties": {
+
+                            "switch_id": {
+                              "description": "Switch ID where the interface or LAG is connected, persistent value free to set by the IXP",
+                              "type": "integer"
+                            },
+                            "if_speed": {
+                              "description": "Speed of the interface or LAG in Mb, i.e. 10G = 10000",
+                              "type": "integer"
+                            },
+                            "if_type": {
+                              "description": "Type of the interface or LAG",
+                              "type": "string"
+                            }
+                          }
+                        }
+
+
+                    },
+                    "vlan_list": {
+                      "type": "array",
+                      "items":
+                        {
+                          "description": "A single VLAN entry",
+                          "type": "object",
+                          "properties": {
+
+                            "vlan_id": {
+                              "description": "The VLAN ID this connection is placed in, persistent value free to set by the IXP",
+                              "type": "integer"
+                            },
+                            "ipv4": {
+                              "description": "The network's IPv4 address details in this VLAN",
+                              "type": "object",
+                              "properties": {
+
+                                "address": {
+                                  "description": "The IPv4 address",
+                                  "type": "string",
+                                  "format": "ipv4"
+                                },
+                                "as_macro": {
+                                  "description": "The IPv4 AS-MACRO, if applicable",
+                                  "type": "string"
+                                },
+                                "max_prefix": {
+                                  "description": "The max number of prefixes on this connection for IPv4",
+                                  "type": "integer"
+                                },
+                                "routeserver": {
+                                  "description": "Does this IPv4 address connect to the IXP routeserver",
+                                  "type": "boolean"
+                                },
+                                "mac_addresses": {
+                                  "description": "MAC address of the member interface (format: lowercase string xx:xx:xx:xx:xx:xx)",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "services": {
+                                  "description": "Array of IX operated service(s) available from this connection.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "description": "The IX operated service available from this connection.",
+                                        "type": "string",
+                                        "enum": ["ixroutecollector", "ixrouteserver"]
+                                      },
+                                      "os": {
+                                        "description": "Free text field to indicate the operating system of the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "os_version": {
+                                        "description": "Free text field to indicate the operating system version of the route server for informational purposes. Should not be present without os.",
+                                        "type": "string",
+                                      },
+                                      "daemon": {
+                                          "description": "Free text field to indicate the BGP software daemon that provides the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "daemon_version": {
+                                          "description": "Free text field to indicate the BGP software daemon version that provides the route server for informational purposes. Should not be present without daemon.",
+                                        "type": "string",
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ipv6": {
+                              "description": "The network's IPv6 address details in this VLAN",
+                              "type": "object",
+                              "properties": {
+
+                                "address": {
+                                  "description": "The IPv6 address",
+                                  "type": "string",
+                                  "format": "ipv6"
+                                },
+                                "as_macro": {
+                                  "description": "The IPv6 AS-MACRO, if applicable",
+                                  "type": "string"
+                                },
+                                "max_prefix": {
+                                  "description": "The max number of prefixes on this connection for IPv6",
+                                  "type": "integer"
+                                },
+                                "routeserver": {
+                                  "description": "Does this IPv6 address connect to the IXP routeserver",
+                                  "type": "boolean"
+                                },
+                                "mac_addresses": {
+                                  "description": "MAC address of the member interface (format: lowercase string xx:xx:xx:xx:xx:xx)",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "services": {
+                                  "description": "Array of IX operated service(s) available from this connection.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "description": "The IX operated service available from this connection.",
+                                        "type": "string",
+                                        "enum": ["ixroutecollector", "ixrouteserver"]
+                                      },
+                                      "os": {
+                                        "description": "Free text field to indicate the operating system of the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "os_version": {
+                                        "description": "Free text field to indicate the operating system version of the route server for informational purposes. Should not be present without os.",
+                                        "type": "string",
+                                      },
+                                      "daemon": {
+                                          "description": "Free text field to indicate the BGP software daemon that provides the route server for informational purposes.",
+                                        "type": "string",
+                                      },
+                                      "daemon_version": {
+                                          "description": "Free text field to indicate the BGP software daemon version that provides the route server for informational purposes. Should not be present without daemon.",
+                                        "type": "string",
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+
+
+                    }
+                  }
+                }
+
+            }
+          }
+        }
+
+    }
+  }
+}


### PR DESCRIPTION
Following a face to face meeting with @bijals & @nickhilliard & @barryo , this represents the decisions on the outstanding v0.8 PR (#26) as well as @arnoldnipper's good suggestion to bump to v1.0.

What's been left out of this is:

* city in the IX entry: this was discussed in detail in #26. 
* modules in switch entry: there is just no easy clean way to define or parse the information that may end up in here.
* the os/os_version/daemon/daemon_version for route servers/collectors is included but refactored into a services[] array.
* we are not sure of the value of #30 (point of contact). The schema already includes technical support contact details and we expect 99% of people will just add the same email here. 

The JSON schema definition itself validates correctly and both example JSON objects validate against it.