### PR TITLE
Add new field quarantine (bool, not required) to ixp_list > vlan entries

### DIFF
--- a/ixp-member-list.schema.json
+++ b/ixp-member-list.schema.json
@@ -177,6 +177,10 @@
                       "description": "VLAN name",
                       "type": "string"
                     },
+                    "quarantine": {
+                      "description": "Determine if this Vlan is used for quarantine procedures",
+                      "type": "boolean"
+                    },
                     "ipv4": {
                       "description": "IPv4 details in this VLAN",
                       "type": "object",

--- a/ixp-member-list.txt
+++ b/ixp-member-list.txt
@@ -49,7 +49,8 @@
 #       + refactor service_type to an array of objects called 'services'
 #         and add: os: (string, not required), os_version: (string, not required),
 #       daemon: (string, not required), and daemon_version: (string, not required)
-
+# v 1.1 * added new fields to support recent PeeringDB changes
+#       + added quarantine (boolean, not required) field in ixp_list > vlan entries
 
 
 #######################################################################
@@ -160,6 +161,7 @@
             {
                 "id": 0,
                 "name": "ISP",
+                "quarantine": false,
                 "ipv4": {
                     "prefix": "80.249.208.0",
                     "mask_length": 21
@@ -172,6 +174,7 @@
             {
                 "id": 1,
                 "name": "GRX",
+                "quarantine": false,
                 "ipv4": {
                     "prefix": "193.105.101.0",
                     "mask_length": 23


### PR DESCRIPTION
Hello everyone, I would like to propose the following addition to the IX-F member export schema. Some IXPs like INEX, Rheintal IX, etc. use a Quarantine Vlan as part of their onboarding process in which new peers initially get connected to. After performing some manual checks (tcpdump, etc.) by the IX staff, if everything is fine, peers get moved to the actual PEERING-Vlan. Since the Peering-LAN subnet is also used within the Quarantine-Vlan, PeeringDB currently has a conflict because the importer sees two Vlans with the same subnet.  With this change, tools like PeeringDB will be able to determine if a Vlan is used for quarantine purposes.  The field should be optional/not required and in the form of datatype boolean.  Thanks